### PR TITLE
Fix on parsing intalls when request is in another language than english.

### DIFF
--- a/play_scraper/scraper.py
+++ b/play_scraper/scraper.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 try:
     from urllib import quote_plus
     from urlparse import urljoin
@@ -161,8 +162,8 @@ class PlayScraper(object):
             size = size.string.strip()
 
         try:
-            installs = [int(n.replace(',', '')) for n in additional_info.select_one(
-                'div[itemprop="numDownloads"]').string.strip().split(" - ")]
+            installs = [int(re.sub(r'[,.]?', '', n)) for n in re.findall(r'\d{1,3}(?:[,.]\d{3})*', 
+                additional_info.select_one('div[itemprop="numDownloads"]').string.strip())]
         except AttributeError:
             installs = [0, 0]
 


### PR DESCRIPTION
For example in spanish, specially Argentina, installs are:

De 100.000 a 500.000, not 100,000 - 500,000.

Thanks to @fedejaure
