### PR TITLE
Hotfix / Details icon class

### DIFF
--- a/play_scraper/utils.py
+++ b/play_scraper/utils.py
@@ -237,7 +237,7 @@ def parse_app_details(soup):
     :return: a dictionary of app details
     """
     title = soup.select_one('h1[itemprop="name"] span').text
-    icon = (soup.select_one('.dQrBL img.ujDFqe')
+    icon = (soup.select_one('img[class="T75of sHb2Xb"]')
                 .attrs['src']
                 .split('=')[0])
     editors_choice = bool(


### PR DESCRIPTION
#### What this pr do?
* Fix the css class for icon on utils.py

#### Where should the reviewer start?
* play_scraper/utils.py: line 240:
    - Replace line to icon = (soup.select_one('img[class="T75of sHb2Xb"]')

#### Any context you want to provide?
* Consider to update README to include the new icon URLs based on 'https://lh3.ggpht.com/' URL

#### Related tickets
Closes #42 