### PR TITLE
Workaround for missing app icon

### DIFF
--- a/play_scraper/utils.py
+++ b/play_scraper/utils.py
@@ -237,9 +237,15 @@ def parse_app_details(soup):
     :return: a dictionary of app details
     """
     title = soup.select_one('h1[itemprop="name"] span').text
-    icon = (soup.select_one('.dQrBL img.ujDFqe')
-                .attrs['src']
-                .split('=')[0])
+    
+    try:
+        icon = (soup.select_one('.dQrBL img.ujDFqe')
+                    .attrs['src'])
+        if icon is not None:
+            icon = icon.split('=')[0]
+    except AttributeError:
+        icon = None
+        
     editors_choice = bool(
         soup.select_one('meta[itemprop="editorsChoiceBadgeUrl"]'))
 


### PR DESCRIPTION
Inserted a try/except AttributeError in parse_app_details (same as for other attributes for consistency). 