### PR TITLE
Fix categories lookup, descriptions, + test failure.

### DIFF
--- a/play_scraper/scraper.py
+++ b/play_scraper/scraper.py
@@ -251,15 +251,13 @@ class PlayScraper(object):
         and returns a list of all available categories.
         """
         categories = {}
-        strainer = SoupStrainer('ul', {'class': 'submenu-item-wrapper'})
 
         response = send_request('GET', s.BASE_URL, params=self.params)
         soup = BeautifulSoup(response.content,
                              'lxml',
-                             from_encoding='utf8',
-                             parse_only=strainer)
-        category_links = soup.select('a.child-submenu-link')
-        category_links += soup.select('a.parent-submenu-link')
+                             from_encoding='utf8')
+
+        category_links = soup.select('div[id*="action-dropdown-children"] a[href*="category"]')
         age_query = '?age='
 
         for cat in category_links:

--- a/play_scraper/utils.py
+++ b/play_scraper/utils.py
@@ -262,7 +262,7 @@ def parse_app_details(soup):
         video = None
 
     description_soup = soup.select_one(
-        'div[itemprop="description"] content div')
+        'div[itemprop="description"] span div')
     if description_soup:
         description = '\n'.join(description_soup.stripped_strings)
         description_html = description_soup.encode_contents()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -121,7 +121,7 @@ class DetailsTest(ScraperTestBase):
         self.assertEqual(len(DETAIL_KEYS), len(app_data.keys()))
         self.assertEqual('com.android.chrome', app_data['app_id'])
         self.assertEqual(['COMMUNICATION'], app_data['category'])
-        self.assertEqual('1,000,000,000+', app_data['installs'])
+        self.assertEqual('5,000,000,000+', app_data['installs'])
         self.assertEqual('Google LLC', app_data['developer'])
         self.assertTrue(all(x is not None and x.startswith('https://')
                             for x in app_data['screenshots']))


### PR DESCRIPTION
**Proposed Changes**:
- Update `category` parsing to directly select category URL elements (fixes failing category tests).
- Update `description` parsing to use new element hierarchy traversal (fixes #50).
- Update `test_fetching_app_with_all_details` test case to use updated download count.