### PR TITLE
Add proxy support

### DIFF
--- a/play_scraper/api.py
+++ b/play_scraper/api.py
@@ -11,7 +11,7 @@ play_scraper.api
 from play_scraper import scraper
 
 
-def details(app_id, hl="en", gl="us"):
+def details(app_id, hl="en", gl="us", **kwargs):
     """Sends a GET request to the app's info page, parses the app's details, and
     returns them as a dict.
 
@@ -19,7 +19,7 @@ def details(app_id, hl="en", gl="us"):
     :return: a dictionary of app details
     """
     s = scraper.PlayScraper(hl, gl)
-    return s.details(app_id)
+    return s.details(app_id, **kwargs)
 
 
 def collection(collection, category=None, hl="en", gl="us", **kwargs):
@@ -55,7 +55,7 @@ def developer(developer, hl="en", gl="us", **kwargs):
     return s.developer(developer, **kwargs)
 
 
-def suggestions(query, hl="en", gl="us"):
+def suggestions(query, hl="en", gl="us", **kwargs):
     """Sends a GET request to the Play Store's suggestion API and returns up to
     five autocompleted suggested query strings in a list.
 
@@ -63,10 +63,10 @@ def suggestions(query, hl="en", gl="us"):
     :return: a list of suggestion strings
     """
     s = scraper.PlayScraper(hl, gl)
-    return s.suggestions(query)
+    return s.suggestions(query, **kwargs)
 
 
-def search(query, page=None, detailed=False, hl="en", gl="us"):
+def search(query, page=None, detailed=False, hl="en", gl="us", **kwargs):
     """Sends a POST request and retrieves a list of applications matching
     the query term(s).
 
@@ -76,10 +76,10 @@ def search(query, page=None, detailed=False, hl="en", gl="us"):
     :return: a list of apps matching search terms
     """
     s = scraper.PlayScraper(hl, gl)
-    return s.search(query, page, detailed)
+    return s.search(query, page, detailed, **kwargs)
 
 
-def similar(app_id, detailed=False, hl="en", gl="us"):
+def similar(app_id, detailed=False, hl="en", gl="us", **kwargs):
     """Sends a GET request, follows the redirect, and retrieves a list of
     applications similar to the specified app.
 
@@ -88,14 +88,14 @@ def similar(app_id, detailed=False, hl="en", gl="us"):
     :return: a list of similar apps
     """
     s = scraper.PlayScraper(hl, gl)
-    return s.similar(app_id, detailed=detailed)
+    return s.similar(app_id, detailed=detailed, **kwargs)
 
 
-def categories(hl="en", gl="us", ignore_promotions=True):
+def categories(hl="en", gl="us", ignore_promotions=True, **kwargs):
     """Sends a GET request to the front page (app store base url), parses and
     returns a list of all available categories.
 
     Note: May contain some promotions, e.g. "Popular Characters"
     """
     s = scraper.PlayScraper(hl, gl)
-    return s.categories(ignore_promotions)
+    return s.categories(ignore_promotions, **kwargs)

--- a/play_scraper/utils.py
+++ b/play_scraper/utils.py
@@ -94,6 +94,7 @@ def send_request(
     timeout=30,
     verify=True,
     allow_redirects=False,
+    **kwargs,
 ):
     """Sends a request to the url and returns the response.
 
@@ -121,6 +122,7 @@ def send_request(
             timeout=timeout,
             verify=verify,
             allow_redirects=allow_redirects,
+            **kwargs,
         )
         if not response.status_code == requests.codes.ok:
             response.raise_for_status()

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist = py27, py32, py33, py34, py35, py36, py37
 
 [testenv]
-deps = -rrequirements.txt
+deps = -r requirements.txt
 usedevelop = True
 commands =
     python -m unittest discover
-


### PR DESCRIPTION
From Red Points we decided to use this package to scrape the google play store. However, we needed to be able to pass proxies to the request. To do so, I have added the possibility of adding keyword arguments to each of the end points in the package which, in turn, will be passed to the `send_request` method to be passed onto request.

This change is 100% backwards compatible and adds more flexibility to the code so that requests can be fine-tuned further but the default parameters were left intact.